### PR TITLE
Port OpenGL based render engine with minimal shape support

### DIFF
--- a/geometry/render/gl_renderer/BUILD.bazel
+++ b/geometry/render/gl_renderer/BUILD.bazel
@@ -7,6 +7,7 @@ load(
     "drake_cc_package_library",
 )
 load("//tools/lint:lint.bzl", "add_lint_tests")
+load("//tools/skylark:test_tags.bzl", "vtk_test_tags")
 load(
     "defs.bzl",
     "drake_cc_library_gl_ubuntu_only",
@@ -22,7 +23,9 @@ drake_cc_package_library_gl_per_os(
     ],
     ubuntu_deps = [
         ":opengl_context",
+        ":opengl_geometry",
         ":render_engine_gl",
+        ":shader_program",
     ],
 )
 
@@ -42,6 +45,16 @@ drake_cc_library_gl_ubuntu_only(
     ],
 )
 
+drake_cc_library_gl_ubuntu_only(
+    name = "opengl_geometry",
+    hdrs = ["opengl_geometry.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":opengl_context",
+        "//math:geometric_transform",
+    ],
+)
+
 # The pure OpenGL-based render engine implementation.
 drake_cc_library(
     name = "render_engine_gl",
@@ -55,6 +68,7 @@ drake_cc_library(
     hdrs = select({
         "//tools/cc_toolchain:apple": ["render_engine_gl_factory.h"],
         "//conditions:default": [
+            "buffer_dim.h",
             "render_engine_gl.h",
             "render_engine_gl_factory.h",
         ],
@@ -62,10 +76,23 @@ drake_cc_library(
     deps = select({
         "//tools/cc_toolchain:apple": ["//geometry/render:render_engine"],
         "//conditions:default": [
-            ":opengl_context",
+            ":opengl_geometry",
+            ":shader_program",
+            "//common:essential",
             "//geometry/render:render_engine",
+            "//systems/sensors:image",
         ],
     }),
+)
+
+drake_cc_library_gl_ubuntu_only(
+    name = "shader_program",
+    srcs = ["shader_program.cc"],
+    hdrs = ["shader_program.h"],
+    deps = [
+        ":opengl_context",
+        "//common:essential",
+    ],
 )
 
 drake_cc_googletest(
@@ -88,8 +115,17 @@ drake_cc_googletest(
         "//tools/cc_toolchain:apple": ["--gtest_filter=-*"],
         "//conditions:default": [],
     }),
+    data = [
+        "//systems/sensors:test_models",
+    ],
+    tags = vtk_test_tags() + [
+        "manual",
+    ],
     deps = [
         ":render_engine_gl",
+        "//common:find_resource",
+        "//geometry/render:render_label",
+        "//systems/sensors:color_palette",
     ],
 )
 

--- a/geometry/render/gl_renderer/BUILD.bazel
+++ b/geometry/render/gl_renderer/BUILD.bazel
@@ -34,7 +34,12 @@ drake_cc_library_gl_ubuntu_only(
         "opengl_includes.h",
     ],
     visibility = ["//visibility:private"],
-    deps = ["@opengl"],
+    deps = [
+        "//common:essential",
+        "@glew",
+        "@glut",
+        "@opengl",
+    ],
 )
 
 # The pure OpenGL-based render engine implementation.
@@ -59,6 +64,20 @@ drake_cc_library(
         "//conditions:default": [
             ":opengl_context",
             "//geometry/render:render_engine",
+        ],
+    }),
+)
+
+drake_cc_googletest(
+    name = "opengl_context_test",
+    args = select({
+        "//tools/cc_toolchain:apple": ["--gtest_filter=-*"],
+        "//conditions:default": [],
+    }),
+    deps = select({
+        "//tools/cc_toolchain:apple": [],
+        "//conditions:default": [
+            ":opengl_context",
         ],
     }),
 )

--- a/geometry/render/gl_renderer/buffer_dim.h
+++ b/geometry/render/gl_renderer/buffer_dim.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "drake/common/drake_copyable.h"
+#include "drake/common/hash.h"
+#include "drake/geometry/render/gl_renderer/opengl_includes.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace gl {
+
+/** Simple class for recording the dimensions of a render target. */
+class BufferDim {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(BufferDim)
+
+  BufferDim(int width, int height) : width_(width), height_(height) {}
+
+  int width() const { return width_; }
+  int height() const { return height_; }
+
+  /** Implements the @ref hash_append concept.  */
+  template <class HashAlgorithm>
+  friend void hash_append(HashAlgorithm& hasher,
+                          const BufferDim& dim) noexcept {
+    using drake::hash_append;
+    hash_append(hasher, dim.width_);
+    hash_append(hasher, dim.height_);
+  }
+
+  bool operator==(const BufferDim& dim) const {
+    return width_ == dim.width_ && height_ == dim.height_;
+  }
+
+ private:
+  int width_{-1};
+  int height_{-1};
+};
+
+/** The collection of OpenGL objects which define a render target --
+ essentially, a 2D image that the depth data gets rendered to.  */
+struct RenderTarget {
+  GLuint frame_buffer;
+  GLuint texture;
+  GLuint render_buffer;
+};
+
+}  // namespace gl
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake
+
+namespace std {
+
+/** Provides std::hash<BufferDim>.  */
+template <>
+struct hash<drake::geometry::render::gl::BufferDim>
+    : public drake::DefaultHash {};
+}  // namespace std

--- a/geometry/render/gl_renderer/opengl_context.cc
+++ b/geometry/render/gl_renderer/opengl_context.cc
@@ -1,15 +1,128 @@
 #include "drake/geometry/render/gl_renderer/opengl_context.h"
 
-// TODO(tehbelinda): Move this to opengl_includes.h in follow-up PR.
-#include <GL/glx.h>
+#include <algorithm>
+
+#include "drake/common/drake_throw.h"
+#include "drake/common/text_logging.h"
 
 namespace drake {
 namespace geometry {
 namespace render {
 namespace gl {
+
 namespace {
 
+void gl_debug_callback(GLenum, GLenum type, GLuint, GLenum severity, GLsizei,
+                       const GLchar* message, const void*) {
+  drake::log()->error(
+      "GL CALLBACK: {:s} type = 0x{:x}, severity = 0x{:x}, message = {:s}",
+      (type == GL_DEBUG_TYPE_ERROR ? "** GL_ERROR **" : ""), type, severity,
+      message);
 }
+
+}  // namespace
+
+class OpenGlContext::Impl {
+ public:
+  explicit Impl(bool debug = false) {
+    // See Offscreen Rendering section here:
+    // https://sidvind.com/index.php?title=Opengl/windowless
+
+    InitializeGlut();
+
+    // Create a window to get an OpenGL context and hide it since we don't want
+    // to display anything yet.
+    glutInitWindowSize(320, 240);
+    glutInitWindowPosition(0, 0);
+    window_id_ = glutCreateWindow("Window");
+    glutHideWindow();
+
+    GLenum err = glewInit();
+    if (GLEW_OK != err) {
+      throw std::runtime_error(fmt::format(
+          "Error initializing OpenGL Context for RenderEngineGL: {}.",
+          glewGetErrorString(err)));
+    }
+
+    is_initialized_ = true;
+
+    // Debug.
+    if (debug) {
+      drake::log()->info("Vendor: {}\n",
+                         reinterpret_cast<const char*>(glGetString(GL_VENDOR)));
+      glEnable(GL_DEBUG_OUTPUT);
+      glDebugMessageCallback(gl_debug_callback, 0);
+    }
+  }
+
+  ~Impl() {
+    if (window_id_ != 0) {
+      glutDestroyWindow(window_id_);
+    }
+  }
+
+  void make_current() const {
+    if (glutGetWindow() != window_id_) {
+        glutSetWindow(window_id_);
+    }
+  }
+
+  bool is_initialized() const { return is_initialized_; }
+
+  static GLint max_texture_size() {
+    GLint res;
+    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &res);
+    return res;
+  }
+
+  static GLint max_renderbuffer_size() {
+    GLint res;
+    glGetIntegerv(GL_MAX_RENDERBUFFER_SIZE, &res);
+    return res;
+  }
+
+ private:
+  // The GLUT library should only be initialized once so we need to keep track
+  // of whether glutInit has already been called.
+  static void InitializeGlut() {
+      if (!is_glut_initialized_) {
+        // Dummy argc and argv values are required arguments for glutInit.
+        int argc = 1;
+        char* argv[1] = {const_cast<char*>("")};
+        glutInit(&argc, argv);
+        is_glut_initialized_ = true;
+      }
+  }
+  static bool is_glut_initialized_;
+
+  bool is_initialized_{false};
+  int window_id_{0};
+};
+bool OpenGlContext::Impl::is_glut_initialized_{false};
+
+OpenGlContext::OpenGlContext(bool debug)
+    : impl_(new OpenGlContext::Impl(debug)) {}
+
+OpenGlContext::~OpenGlContext() = default;
+
+void OpenGlContext::make_current() const { impl_->make_current(); }
+
+bool OpenGlContext::is_initialized() const { return impl_->is_initialized(); }
+
+GLint OpenGlContext::max_texture_size() {
+  return OpenGlContext::Impl::max_texture_size();
+}
+
+GLint OpenGlContext::max_renderbuffer_size() {
+  return OpenGlContext::Impl::max_renderbuffer_size();
+}
+
+GLint OpenGlContext::max_allowable_texture_size() {
+  // TODO(duy): Take into account CUDA limits.
+  return std::min(OpenGlContext::max_texture_size(),
+                  OpenGlContext::max_renderbuffer_size());
+}
+
 }  // namespace gl
 }  // namespace render
 }  // namespace geometry

--- a/geometry/render/gl_renderer/opengl_context.h
+++ b/geometry/render/gl_renderer/opengl_context.h
@@ -9,10 +9,43 @@ namespace geometry {
 namespace render {
 namespace gl {
 
-/** Temporary dummy class for building dummy RenderEngineGl dependencies.  */
+/** Handle OpenGL context initialization, clean-up and generic OpenGL queries.
+ This class creates and owns a new context upon construction. Rendering classes
+ need to keep their own OpenGlContext and ensure that they switch to it using
+ `make_current()` before any OpenGL calls.
+ */
 class OpenGlContext {
  public:
-  static void Dummy() {}
+  /** Constructor. Open an X display and initialize an OpenGL context. The
+   display will be open and ready for offscreen rendering, but no window is
+   visible.
+   @param debug  If true, diagnostics about the initialization of the context
+   will be written to the Drake log.
+   */
+  explicit OpenGlContext(bool debug = false);
+
+  /** Releases context if it is not owned.  */
+  ~OpenGlContext();
+
+  /** Makes this context current or throws.  */
+  void make_current() const;
+
+  bool is_initialized() const;
+
+  /** Returns the specified values for the current OpenGL context.
+   @note Even if invoked via an instance, they may not reflect that instance's
+   configuration if the instance differs from whichever context is current.  */
+  static GLint max_texture_size();
+  static GLint max_renderbuffer_size();
+  static GLint max_allowable_texture_size();
+
+ private:
+  // Note: we are dependent on `GL/glx.h` but don't want to let that bleed into
+  // other code. So, we pimpl this up so that glx.h lives only in the
+  // implementation.
+  class Impl;
+
+  std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace gl

--- a/geometry/render/gl_renderer/opengl_geometry.h
+++ b/geometry/render/gl_renderer/opengl_geometry.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <limits>
+
+#include "drake/geometry/render/gl_renderer/opengl_includes.h"
+#include "drake/math/rigid_transform.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace gl {
+
+/** For a fixed OpenGL context, defines the definition of a mesh geometry. The
+ geometry is defined by the handles to various objects in the OpenGL context.
+ If the context is changed or otherwise invalidated, these handles will no
+ longer be valid.  */
+struct OpenGlGeometry {
+  GLuint vertex_array{kInvalid};
+  GLuint vertex_buffer{kInvalid};
+  GLuint index_buffer{kInvalid};
+  int index_buffer_size{0};
+
+  /** Reports true if `this` has been defined with meaningful values.  */
+  bool is_defined() const {
+    return vertex_array != kInvalid && vertex_buffer != kInvalid &&
+           index_buffer != kInvalid;
+  }
+
+  /** Throws an exception with the given `message` if `this` hasn't been
+   populated with meaningful values.  */
+  void throw_if_undefined(const char* message) {
+    if (!is_defined()) throw std::logic_error(message);
+  }
+
+  /** The value of an object that should be considered invalid.  */
+  static constexpr GLuint kInvalid = std::numeric_limits<GLuint>::max();
+};
+
+/** An instance of a geometry in the renderer - the geometry definition and the
+ pose of that geometry in the world frame.  */
+struct OpenGlInstance {
+  OpenGlInstance(const OpenGlGeometry& g_in,
+                 const math::RigidTransformd& pose_in,
+                 const Vector3<double>& scale_in)
+      : geometry(g_in), X_WG(pose_in), scale(scale_in) {}
+  OpenGlGeometry geometry;
+  math::RigidTransformd X_WG;
+  // The scale factors providing the basis for non-unit geometry.
+  Vector3<double> scale;
+};
+
+}  // namespace gl
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/gl_renderer/opengl_includes.h
+++ b/geometry/render/gl_renderer/opengl_includes.h
@@ -1,12 +1,13 @@
-/// @file
-///
-/// Provides a one-stop shop for pulling in the OpenGl symbols in with the
-/// required extensions. Handles the ordering and the required macros in one
-/// place so dependent headers don't have to worry about it.
+/** @file
+ Provides a one-stop shop for pulling in the OpenGl symbols in with the
+ required extensions. Note that this distinguishes 'generic' OpenGl headers
+ from those that are OS-based. This handles the ordering and the required
+ macros in one place so dependent headers don't have to worry about it.
+ */
 
 #pragma once
 
 #define GL_GLEXT_PROTOTYPES
-#include <GL/gl.h>
-#include <GL/glext.h>
+#include <GL/glew.h>
+#include <GL/glut.h>
 #undef GL_GLEXT_PROTOTYPES

--- a/geometry/render/gl_renderer/render_engine_gl.cc
+++ b/geometry/render/gl_renderer/render_engine_gl.cc
@@ -10,7 +10,6 @@ using systems::sensors::ImageLabel16I;
 using systems::sensors::ImageRgba8U;
 
 RenderEngineGl::RenderEngineGl() {
-  gl::OpenGlContext::Dummy();
 }
 
 void RenderEngineGl::UpdateViewpoint(const RigidTransformd&) {}

--- a/geometry/render/gl_renderer/render_engine_gl.cc
+++ b/geometry/render/gl_renderer/render_engine_gl.cc
@@ -1,49 +1,443 @@
 #include "drake/geometry/render/gl_renderer/render_engine_gl.h"
 
+#include <fmt/format.h>
+
 namespace drake {
 namespace geometry {
 namespace render {
+namespace gl {
 
 using math::RigidTransformd;
+using std::make_shared;
+using std::string;
+using std::unique_ptr;
+using std::unordered_map;
 using systems::sensors::ImageDepth32F;
 using systems::sensors::ImageLabel16I;
 using systems::sensors::ImageRgba8U;
 
-RenderEngineGl::RenderEngineGl() {
+namespace {
+
+// Data to pass through the reification process.
+struct RegistrationData {
+  const GeometryId id;
+  const RigidTransformd& X_WG;
+};
+
+}  // namespace
+
+RenderEngineGl::RenderEngineGl()
+    : opengl_context_(make_shared<OpenGlContext>()),
+      shader_program_(make_shared<ShaderProgram>()),
+      frame_buffers_(make_shared<unordered_map<BufferDim, RenderTarget>>()),
+      visuals_() {
+  if (!opengl_context_->is_initialized())
+    throw std::runtime_error("OpenGL Context has not been initialized.");
+
+  // Setup shader program.
+  const string kVertexShader = R"__(
+#version 450
+
+layout(location = 0) in vec3 p_Model;
+out float depth;
+uniform mat4 model_view_matrix;
+uniform mat4 projection_matrix;
+
+void main() {
+  vec4 p_Camera = model_view_matrix * vec4(p_Model, 1);
+  depth = -p_Camera.z;
+  gl_Position = projection_matrix * p_Camera;
+})__";
+  const string kFragmentShader = R"__(
+#version 450
+
+in float depth;
+layout(location = 0) out float inverse_depth;
+uniform float depth_z_near;
+uniform float depth_z_far;
+
+void main() {
+  if (depth < depth_z_near)
+    // This is ok for OpenGL >= 4.1:
+    // https://stackoverflow.com/questions/10435253/glsl-infinity-constant
+    inverse_depth = 1.0 / 0.0;
+  else if (depth > depth_z_far)
+    inverse_depth = 0.0;
+  else
+    inverse_depth = 1.0 / depth;
+})__";
+  shader_program_->LoadFromSources(kVertexShader, kFragmentShader);
 }
 
-void RenderEngineGl::UpdateViewpoint(const RigidTransformd&) {}
+void RenderEngineGl::UpdateViewpoint(const RigidTransformd& X_WR) {
+  X_CW_ = X_WR.inverse();
+}
 
 void RenderEngineGl::RenderColorImage(const CameraProperties&, bool,
                                       ImageRgba8U*) const {
+  throw std::runtime_error("RenderEngineDepthGl cannot render color images");
 }
 
-void RenderEngineGl::RenderDepthImage(const DepthCameraProperties&,
-                                      ImageDepth32F*) const {
+void RenderEngineGl::RenderDepthImage(const DepthCameraProperties& camera,
+                                      ImageDepth32F* depth_image_out) const {
+  opengl_context_->make_current();
+
+  RenderTarget target =
+      const_cast<RenderEngineGl*>(this)->SetCameraProperties(camera);
+
+  RenderAt(X_CW_.GetAsMatrix4().matrix().cast<float>());
+  GetDepthImage(depth_image_out, target);
 }
 
 void RenderEngineGl::RenderLabelImage(const CameraProperties&, bool,
                                       ImageLabel16I*) const {
+  throw std::runtime_error("RenderEngineDepthGl cannot render label images");
 }
 
-bool RenderEngineGl::DoRegisterVisual(GeometryId, const Shape&,
+void RenderEngineGl::SetGLProjectionMatrix(
+    const DepthCameraProperties& camera) {
+  shader_program_->Use();
+  shader_program_->SetUniformValue1f("depth_z_near", camera.z_near);
+  shader_program_->SetUniformValue1f("depth_z_far", camera.z_far);
+
+  static constexpr float kGLZNear = 0.01;
+  static constexpr float kGLZFar = 10.0;
+  static constexpr float kInvZNearMinusZFar = 1. / (kGLZNear - kGLZFar);
+  if (camera.z_near < kGLZNear)
+    throw std::runtime_error(
+        fmt::format("Camera's z_near ({}) is closer than what this renderer "
+                    "can handle ({})",
+                    camera.z_near, kGLZNear));
+  if (camera.z_far > kGLZFar)
+    throw std::runtime_error(
+        fmt::format("Camera's z_far ({}) is farther than what this renderer "
+                    "can handle ({})",
+                    camera.z_far, kGLZFar));
+
+  // https://unspecified.wordpress.com/2012/06/21/calculating-the-gluperspective-matrix-and-other-opengl-matrix-maths/
+  // An OpenGL projection matrix maps points in a camera coordinate to a "clip
+  // coordinate", in which the projection step maps a 3D point into 2D
+  // normalized device coordinate (NDC). Effectively, image corners are mapped
+  // into a square from -1 to 1 in NDC. Hence, the clip coordinate is
+  // essentially a scaled version of the camera coordinate, where the camera
+  // image frustum is scaled into a "square" frustum.
+  //
+  // Because the xy elements of the image corner [f*w/2, f*h/2] is mapped to
+  // [fx*f*w/2, fy*f*h/2] in the "square" clip coordinate by the OpenGL
+  // projection matrix P, we have: fx*f*w/2 == fy*f*h/2, i.e. fx*w == fy*h.
+
+  const float fy = 1.0f / static_cast<float>(tan(camera.fov_y * 0.5));
+  const float fx = fy * camera.height / camera.width;
+  const float A = (kGLZNear + kGLZFar) * kInvZNearMinusZFar;
+  const float B = 2.0f * kGLZNear * kGLZFar * kInvZNearMinusZFar;
+  Eigen::Matrix4f P;
+  // Eigen matrices are col-major, similar to OpenGL.
+  // clang-format off
+  P << fx, 0.0,  0.0, 0.0,
+      0.0, fy,   0.0, 0.0,
+      0.0, 0.0,    A,   B,
+      0.0, 0.0, -1.0, 0.0;
+  // clang-format on
+  auto projection_matrix_id =
+      shader_program_->GetUniformLocation("projection_matrix");
+  glUniformMatrix4fv(projection_matrix_id, 1, GL_FALSE, P.data());
+}
+
+OpenGlGeometry RenderEngineGl::SetupVAO(const VertexBuffer& vertices,
+                                        const IndexBuffer& indices) {
+  OpenGlGeometry geometry;
+  // Create the VAO.
+  glCreateVertexArrays(1, &geometry.vertex_array);
+
+  // Vertex Buffer Object.
+  glCreateBuffers(1, &geometry.vertex_buffer);
+  glNamedBufferStorage(geometry.vertex_buffer,
+                       vertices.size() * sizeof(GLfloat), vertices.data(), 0);
+  // Bind with the VAO.
+  const int kBindingIndex = 0;  // The binding point.
+  glVertexArrayVertexBuffer(geometry.vertex_array, kBindingIndex,
+                            geometry.vertex_buffer, 0, 3 * sizeof(GLfloat));
+
+  // Bind the attribute in vertex shader to the VAO at the same binding point.
+  const int kLocP_ModelAttrib = 0;  // p_Model's location in vertex shader.
+  glVertexArrayAttribFormat(geometry.vertex_array, kLocP_ModelAttrib, 3,
+                            GL_FLOAT, GL_FALSE, 0);
+  glVertexArrayAttribBinding(geometry.vertex_array, kLocP_ModelAttrib,
+                             kBindingIndex);
+  glEnableVertexArrayAttrib(geometry.vertex_array, kLocP_ModelAttrib);
+
+  // Index Buffer Object.
+  glCreateBuffers(1, &geometry.index_buffer);
+  glNamedBufferStorage(geometry.index_buffer, indices.size() * sizeof(GLuint),
+                       indices.data(), 0);
+  // Bind with the VAO.
+  glVertexArrayElementBuffer(geometry.vertex_array, geometry.index_buffer);
+
+  geometry.index_buffer_size = indices.size();
+
+  // Note: We won't need to call the corresponding glDeleteVertexArrays or
+  // glDeleteBuffers. The meshes we store are "canonical" meshes. Even if a
+  // particular GeometryId is removed, it was only referencing its corresponding
+  // canonical mesh. We keep all canonical meshes alive for the lifetime of the
+  // Context for convenient reuse.
+  return geometry;
+}
+
+RenderTarget RenderEngineGl::SetupFBO(const DepthCameraProperties& camera) {
+  // Create a framebuffer object.
+  RenderTarget target;
+  glCreateFramebuffers(1, &target.frame_buffer);
+
+  // Create the texture object to render to.
+  const int kWidth = camera.width;
+  const int kHeight = camera.height;
+  glGenTextures(1, &target.texture);
+  glBindTexture(GL_TEXTURE_2D, target.texture);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, kWidth, kHeight, 0, GL_RED, GL_FLOAT,
+               0);
+  glBindTexture(GL_TEXTURE_2D, 0);
+
+  // Attach the texture to FBO color attachment point.
+  glNamedFramebufferTexture(target.frame_buffer, GL_COLOR_ATTACHMENT0,
+                            target.texture, 0);
+
+  // Create the renderbuffer object, acting as the z buffer.
+  glCreateRenderbuffers(1, &target.render_buffer);
+  glNamedRenderbufferStorage(target.render_buffer, GL_DEPTH_COMPONENT, kWidth,
+                             kHeight);
+  // Attach the renderbuffer to FBO's depth attachment point.
+  glNamedFramebufferRenderbuffer(target.frame_buffer, GL_DEPTH_ATTACHMENT,
+                                 GL_RENDERBUFFER, target.render_buffer);
+
+  // Check FBO status.
+  GLenum status =
+      glCheckNamedFramebufferStatus(target.frame_buffer, GL_FRAMEBUFFER);
+  if (status != GL_FRAMEBUFFER_COMPLETE) {
+    throw std::runtime_error("FBO creation failed.");
+  }
+
+  // Specify which buffer to be associated with the fragment shader output.
+  GLenum buffers[] = {GL_COLOR_ATTACHMENT0};
+  glNamedFramebufferDrawBuffers(target.frame_buffer, 1, buffers);
+
+  return target;
+}
+
+void RenderEngineGl::SetGLModelViewMatrix(const Eigen::Matrix4f& X_CM) const {
+  auto model_view_matrix_id =
+      shader_program_->GetUniformLocation("model_view_matrix");
+
+  // Our camera frame C wrt the OpenGL's camera frame Cgl.
+  static const Eigen::Matrix4f kX_CglC =
+      (Eigen::Matrix4f() << 1, 0, 0, 0, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1)
+          .finished();
+
+  Eigen::Matrix4f X_CglM = kX_CglC * X_CM;
+  glUniformMatrix4fv(model_view_matrix_id, 1, GL_FALSE, X_CglM.data());
+}
+
+RenderTarget RenderEngineGl::SetCameraProperties(
+    const DepthCameraProperties& camera) {
+  SetGLProjectionMatrix(camera);
+
+  const BufferDim dim{camera.width, camera.height};
+  RenderTarget target;
+  auto iter = frame_buffers_->find(dim);
+  if (iter == frame_buffers_->end()) {
+    target = SetupFBO(camera);
+    frame_buffers_->insert({dim, target});
+  } else {
+    target = iter->second;
+  }
+  glBindFramebuffer(GL_FRAMEBUFFER, target.frame_buffer);
+  glViewport(0, 0, camera.width, camera.height);
+  return target;
+}
+
+void RenderEngineGl::RenderAt(const Eigen::Matrix4f& X_CW) const {
+  shader_program_->Use();
+
+  glClipControl(GL_UPPER_LEFT, GL_NEGATIVE_ONE_TO_ONE);
+  glEnable(GL_DEPTH_TEST);
+  glClear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
+
+  for (const auto& pair : visuals_) {
+    const auto& vis = pair.second;
+    glBindVertexArray(vis.geometry.vertex_array);
+
+    Eigen::DiagonalMatrix<float, 4, 4> scale(
+        Vector4<float>(vis.scale(0), vis.scale(1), vis.scale(2), 1.0));
+    // Create the scaled transform (S_CG = X_CW * X_WG * scale) which poses a
+    // scaled version of a canonical geometry.
+    SetGLModelViewMatrix(X_CW * vis.X_WG.GetAsMatrix4().cast<float>() * scale);
+    glDrawElements(GL_TRIANGLES, vis.geometry.index_buffer_size,
+                   GL_UNSIGNED_INT, 0);
+  }
+  // Unbind the vertex array back to the default of 0.
+  glBindVertexArray(0);
+  shader_program_->Unuse();
+}
+
+void RenderEngineGl::GetDepthImage(ImageDepth32F* depth_image_out,
+                                   const RenderTarget& target) const {
+  glGetTextureImage(target.texture, 0, GL_RED, GL_FLOAT,
+                    depth_image_out->size() * sizeof(GLfloat),
+                    depth_image_out->at(0, 0));
+
+  for (int y = 0; y < depth_image_out->height(); ++y) {
+    for (int x = 0; x < depth_image_out->width(); ++x) {
+      *depth_image_out->at(x, y) = 1.f / *depth_image_out->at(x, y);
+    }
+  }
+}
+
+void RenderEngineGl::ImplementGeometry(const Sphere& sphere, void* user_data) {
+  OpenGlGeometry geometry = GetSphere();
+  const RegistrationData& data = *static_cast<RegistrationData*>(user_data);
+  const double r = sphere.radius();
+  visuals_.emplace(data.id, OpenGlInstance(geometry, data.X_WG,
+                                           Vector3<double>{r, r, r}));
+}
+
+void RenderEngineGl::ImplementGeometry(const HalfSpace&, void* user_data) {
+  OpenGlGeometry geometry = GetHalfSpace();
+  const RegistrationData& data = *static_cast<RegistrationData*>(user_data);
+  visuals_.emplace(
+      data.id, OpenGlInstance(geometry, data.X_WG, Vector3<double>{1, 1, 1}));
+}
+
+bool RenderEngineGl::DoRegisterVisual(GeometryId id, const Shape& shape,
                                       const PerceptionProperties&,
-                                      const RigidTransformd&) {
+                                      const RigidTransformd& X_WG) {
+  opengl_context_->make_current();
+  RegistrationData data{id, RigidTransformd{X_WG}};
+  shape.Reify(this, &data);
   return true;
 }
 
-void RenderEngineGl::DoUpdateVisualPose(GeometryId,
-                                        const RigidTransformd&) {
+void RenderEngineGl::DoUpdateVisualPose(GeometryId id,
+                                        const RigidTransformd& X_WG) {
+  visuals_.at(id).X_WG = X_WG;
 }
 
-bool RenderEngineGl::DoRemoveGeometry(GeometryId) {
-  return false;
+bool RenderEngineGl::DoRemoveGeometry(GeometryId id) {
+  auto iter = visuals_.find(id);
+  if (iter != visuals_.end()) {
+    visuals_.erase(iter);
+    return true;
+  } else {
+    return false;
+  }
 }
 
-std::unique_ptr<RenderEngine> RenderEngineGl::DoClone() const {
-  return std::unique_ptr<RenderEngineGl>(new RenderEngineGl(*this));
+unique_ptr<RenderEngine> RenderEngineGl::DoClone() const {
+  return unique_ptr<RenderEngineGl>(new RenderEngineGl(*this));
 }
 
+OpenGlGeometry RenderEngineGl::GetSphere() {
+  if (!sphere_.is_defined()) {
+    const int kLatitudeBands = 50;
+    const int kLongitudeBands = 50;
+
+    const int tri_count = 2 * (kLatitudeBands - 1) * kLongitudeBands;
+    const int vert_count = (kLatitudeBands - 1) * kLongitudeBands + 2;
+
+    VertexBuffer vertices{vert_count, 3};
+    IndexBuffer indices{tri_count, 3};
+
+    vertices.block<1, 3>(0, 0) << 0.f, 0.f, 1.f;
+
+    // We don't take slices of the sphere that are equidistant along the z-axis.
+    // Instead, we create slices so that the chord length along the perimeter
+    // of the longitudinal circle are equal.
+    int v = 1;
+    int t = 0;
+
+    GLfloat z = cos(M_PI / kLatitudeBands);
+    GLfloat radius = sqrt(1.0 - z * z);
+    int line_start = 1;
+    for (int i = 0; i < kLongitudeBands; ++i) {
+      const GLfloat theta = i * M_PI * 2 / kLongitudeBands;
+      const GLfloat cos_theta = cos(theta);
+      const GLfloat sin_theta = sin(theta);
+      vertices.block<1, 3>(v++, 0) << radius * cos_theta, radius * sin_theta, z;
+      indices.block<1, 3>(t++, 0) << 0, line_start + i,
+          line_start + (i + 1) % kLongitudeBands;
+    }
+
+    // Latitudinal bands
+    for (int latitude = 1; latitude < kLatitudeBands - 1; ++latitude) {
+      int previous_line_start = line_start;
+      line_start += kLongitudeBands;
+      z = cos((latitude + 1) * M_PI / kLatitudeBands);
+      radius = sqrt(1.0f - z * z);
+      for (int i = 0; i < kLongitudeBands; ++i) {
+        const GLfloat theta = i * M_PI * 2 / kLongitudeBands;
+        const GLfloat cos_theta = cos(theta);
+        const GLfloat sin_theta = sin(theta);
+        vertices.block<1, 3>(v++, 0) << radius * cos_theta, radius * sin_theta,
+            z;
+        const int next = (i + 1) % kLongitudeBands;
+        indices.block<1, 3>(t++, 0) << previous_line_start + i, line_start + i,
+            line_start + next;
+        indices.block<1, 3>(t++, 0) << previous_line_start + i,
+            line_start + next, previous_line_start + next;
+      }
+    }
+
+    // South pole fan
+    vertices.block<1, 3>(v++, 0) << 0.f, 0.f, -1.f;
+    DRAKE_DEMAND(v == vert_count);
+    const int south_pole = line_start + kLongitudeBands;
+    for (int i = 0; i < kLongitudeBands; ++i) {
+      indices.block<1, 3>(t++, 0) << line_start + i, south_pole,
+          line_start + (i + 1) % kLongitudeBands;
+    }
+    DRAKE_DEMAND(t == tri_count);
+
+    sphere_ = SetupVAO(vertices, indices);
+  }
+
+  sphere_.throw_if_undefined("Built-in sphere has some invalid objects");
+
+  return sphere_;
+}
+
+OpenGlGeometry RenderEngineGl::GetHalfSpace() {
+  if (!half_space_.is_defined()) {
+    //                 _  y
+    //                  /|
+    //                 /
+    //     3_________________________ 2
+    //     /         ^ z            /
+    //    /          |_            /  --> x
+    //   /           Go           /
+    //  /                        /
+    // /________________________/
+    // 0                         1
+    const GLfloat kHalfSize = 100.f;
+    VertexBuffer vertices{4, 3};
+    vertices << -kHalfSize, -kHalfSize, 0.f, kHalfSize, -kHalfSize, 0.f,
+        kHalfSize, kHalfSize, 0.f, -kHalfSize, kHalfSize, 0.f;
+
+    IndexBuffer indices{2, 3};
+    indices << 0, 1, 2, 0, 2, 3;
+    half_space_ = SetupVAO(vertices, indices);
+  }
+
+  half_space_.throw_if_undefined(
+      "Built-in half space has some invalid objects");
+
+  return half_space_;
+}
+
+RenderEngineGl::~RenderEngineGl() = default;
+
+}  // namespace gl
 }  // namespace render
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render/gl_renderer/render_engine_gl.h
+++ b/geometry/render/gl_renderer/render_engine_gl.h
@@ -1,54 +1,143 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <unordered_map>
 
+#include "drake/common/eigen_types.h"
+#include "drake/geometry/geometry_roles.h"
+#include "drake/geometry/render/camera_properties.h"
+#include "drake/geometry/render/gl_renderer/buffer_dim.h"
 #include "drake/geometry/render/gl_renderer/opengl_context.h"
+#include "drake/geometry/render/gl_renderer/opengl_geometry.h"
+#include "drake/geometry/render/gl_renderer/shader_program.h"
 #include "drake/geometry/render/render_engine.h"
+#include "drake/math/rigid_transform.h"
+#include "drake/systems/sensors/image.h"
 
 namespace drake {
 namespace geometry {
 namespace render {
+namespace gl {
 
 /** See documentation of MakeRenderEngineGl().  */
 class RenderEngineGl final : public RenderEngine {
  public:
+  /** \name Does not allow public copy, move, or assignment  */
+  //@{
+  RenderEngineGl& operator=(const RenderEngineGl&) = delete;
+  RenderEngineGl(RenderEngineGl&&) = delete;
+  RenderEngineGl& operator=(RenderEngineGl&&) = delete;
+  //@}}
+
   RenderEngineGl();
 
-  /** @see RenderEngine::UpdateViewpoint().  */
-  void UpdateViewpoint(const math::RigidTransformd& X_WR) final;
+  ~RenderEngineGl() override;
 
-  /** @see RenderEngine::RenderColorImage().  */
+  /** Inherits RenderEngine::UpdateViewpoint().  */
+  void UpdateViewpoint(const math::RigidTransformd& X_WR) override;
+
+  /** Inherits RenderEngine::RenderColorImage().  */
   void RenderColorImage(
       const CameraProperties& camera, bool show_window,
-      systems::sensors::ImageRgba8U* color_image_out) const final;
+      systems::sensors::ImageRgba8U* color_image_out) const override;
 
-  /** @see RenderEngine::RenderDepthImage().  */
+  /** Inherits RenderEngine::RenderDepthImage().  */
   void RenderDepthImage(
       const DepthCameraProperties& camera,
-      systems::sensors::ImageDepth32F* depth_image_out) const final;
+      systems::sensors::ImageDepth32F* depth_image_out) const override;
 
-  /** @see RenderEngine::RenderLabelImage().  */
+  /** Inherits RenderEngine::RenderLabelImage().  */
   void RenderLabelImage(
       const CameraProperties& camera, bool show_window,
-      systems::sensors::ImageLabel16I* label_image_out) const final;
+      systems::sensors::ImageLabel16I* label_image_out) const override;
+
+  /** @name    Shape reification  */
+  //@{
+  using RenderEngine::ImplementGeometry;
+  void ImplementGeometry(const Sphere& sphere, void* user_data) override;
+  void ImplementGeometry(const HalfSpace& half_space, void* user_data) override;
+  //@}
 
  private:
   // @see RenderEngine::DoRegisterVisual().
-  bool DoRegisterVisual(GeometryId id, const Shape& shape,
+  bool DoRegisterVisual(GeometryId id,
+                        const Shape& shape,
                         const PerceptionProperties& properties,
-                        const math::RigidTransformd& X_WG) final;
+                        const math::RigidTransformd& X_WG) override;
 
   // @see RenderEngine::DoUpdateVisualPose().
   void DoUpdateVisualPose(GeometryId id,
-                          const math::RigidTransformd& X_WG) final;
+                          const math::RigidTransformd& X_WG) override;
 
   // @see RenderEngine::DoRemoveGeometry().
-  bool DoRemoveGeometry(GeometryId id) final;
+  bool DoRemoveGeometry(GeometryId id) override;
 
-  // @see RenderEngine::DoClone().
-  std::unique_ptr<RenderEngine> DoClone() const final;
+  // see RenderEngine::DoClone().
+  std::unique_ptr<RenderEngine> DoClone() const override;
+
+  // Copy constructor used for cloning.
+  RenderEngineGl(const RenderEngineGl& other) = default;
+
+  // Render inverse depth of the object at a specific pose in the camera frame.
+  void RenderAt(const Eigen::Matrix4f& X_CM) const;
+
+  // Obtain the depth image of rendered from a specific object pose. This is
+  // slow because it reads the buffer back from the GPU.
+  void GetDepthImage(systems::sensors::ImageDepth32F* depth_image_out,
+                     const RenderTarget& target) const;
+
+  // Provide triangle mesh definitions of the various geometries supported by
+  // this renderer: sphere, and halfspace.
+  OpenGlGeometry GetSphere();
+  OpenGlGeometry GetHalfSpace();
+
+  // Infrastructure for setting up the frame buffer object.
+  RenderTarget SetupFBO(const DepthCameraProperties& camera);
+
+  // Configure the model view and projection matrices.
+  void SetGLProjectionMatrix(const DepthCameraProperties& camera);
+  void SetGLModelViewMatrix(const Eigen::Matrix4f& X_CM) const;
+
+  // Configure the OpenGL properties dependent on the camera properties.
+  RenderTarget SetCameraProperties(const DepthCameraProperties& camera);
+
+  // Configure the vertex array object for a triangle mesh.
+  using VertexBuffer =
+      Eigen::Matrix<GLfloat, Eigen::Dynamic, 3, Eigen::RowMajor>;
+  using IndexBuffer = Eigen::Matrix<GLuint, Eigen::Dynamic, 3, Eigen::RowMajor>;
+  OpenGlGeometry SetupVAO(const VertexBuffer& vertices,
+                          const IndexBuffer& indices);
+
+  // The cached value transformation between camera and world frame.
+  mutable math::RigidTransformd X_CW_;
+
+  // All clones of this context share the same underlying opengl_context_. They
+  // share geometry and frame buffer objects. The following structs are either
+  // shared, or copy safe w.r.t. the shared context.
+  std::shared_ptr<OpenGlContext> opengl_context_;
+
+  // All of the objects below here *depend* on the OpenGL context. Right now,
+  // I'm having each instance of the renderer share these OpenGl objects and
+  // the context. If I'm going to do that, I may be better off making them
+  // part of the Context rather than part of the renderer.
+  std::shared_ptr<ShaderProgram> shader_program_;
+
+  // One OpenGLGeometry per primitive type -- allow for instancing.
+  OpenGlGeometry sphere_;
+  OpenGlGeometry half_space_;
+
+  // Mapping from width and height to a RenderTarget. Allows for the re-use of
+  // frame buffers if they are of the same dimension.
+  std::shared_ptr<std::unordered_map<BufferDim, RenderTarget>> frame_buffers_;
+
+  // Mapping from RenderIndex to the visual data associated with that geometry.
+  // This is copied so independent renderers can have different *instances* but
+  // the instances still refer to the same, shared, underlying geometry.
+  std::unordered_map<GeometryId, OpenGlInstance> visuals_;
 };
 
+}  // namespace gl
 }  // namespace render
 }  // namespace geometry
 }  // namespace drake

--- a/geometry/render/gl_renderer/render_engine_gl_factory.cc
+++ b/geometry/render/gl_renderer/render_engine_gl_factory.cc
@@ -7,7 +7,7 @@ namespace geometry {
 namespace render {
 
 std::unique_ptr<RenderEngine> MakeRenderEngineGl() {
-  return std::make_unique<RenderEngineGl>();
+  return std::make_unique<gl::RenderEngineGl>();
 }
 
 }  // namespace render

--- a/geometry/render/gl_renderer/render_engine_gl_factory.h
+++ b/geometry/render/gl_renderer/render_engine_gl_factory.h
@@ -9,14 +9,10 @@ namespace drake {
 namespace geometry {
 namespace render {
 
-/** Constructs a RenderEngine implementation which uses a purely OpenGL
- renderer. Currently this uses a temporary dummy implementation. Due to the lack
- of support on Mac, this has been initially introduced to verify platform
- specific (i.e. Ubuntu only) conditionals for building and installing. The rest
- of the implementation will be ported over once the conditionalizing is no
- longer considered a risk.
- <!-- TODO(tehbelinda): Complete port of RenderEngineGl. -->
- */
+/** Constructs an optimized simple renderer based on direct calls to the OpenGL
+ API. For now, it only renders depth images, i.e. no color or label images are
+ supported. The presence of PerceptionProperties is enough to register the
+ geometry as no specific properties are required.   */
 std::unique_ptr<RenderEngine> MakeRenderEngineGl();
 
 }  // namespace render

--- a/geometry/render/gl_renderer/shader_program.cc
+++ b/geometry/render/gl_renderer/shader_program.cc
@@ -1,0 +1,111 @@
+#include "drake/geometry/render/gl_renderer/shader_program.h"
+
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace gl {
+
+namespace {
+
+GLuint CompileShader(GLuint shader_type, const std::string& shader_code) {
+  GLuint shader_id = glCreateShader(shader_type);
+  char const* source_ptr = shader_code.c_str();
+  glShaderSource(shader_id, 1, &source_ptr, NULL);
+  glCompileShader(shader_id);
+
+  // Check compilation result.
+  GLint result;
+  int info_log_length;
+  glGetShaderiv(shader_id, GL_COMPILE_STATUS, &result);
+  glGetShaderiv(shader_id, GL_INFO_LOG_LENGTH, &info_log_length);
+  if (info_log_length > 0) {
+    std::vector<char> error_message(info_log_length + 1);
+    glGetShaderInfoLog(shader_id, info_log_length, NULL, &error_message[0]);
+    throw std::runtime_error(&error_message[0]);
+  }
+
+  return shader_id;
+}
+
+}  // namespace
+
+void ShaderProgram::LoadFromSources(const std::string& vertex_shader_source,
+                                    const std::string& fragment_shader_source) {
+  // Compile.
+  GLuint vertex_shader_id =
+      CompileShader(GL_VERTEX_SHADER, vertex_shader_source);
+  GLuint fragment_shader_id =
+      CompileShader(GL_FRAGMENT_SHADER, fragment_shader_source);
+
+  // Link.
+  program_id_ = glCreateProgram();
+  glAttachShader(program_id_, vertex_shader_id);
+  glAttachShader(program_id_, fragment_shader_id);
+  glLinkProgram(program_id_);
+
+  // Clean up.
+  glDetachShader(program_id_, vertex_shader_id);
+  glDetachShader(program_id_, fragment_shader_id);
+  glDeleteShader(vertex_shader_id);
+  glDeleteShader(fragment_shader_id);
+
+  // Check.
+  GLint result;
+  int info_log_length;
+  glGetProgramiv(program_id_, GL_LINK_STATUS, &result);
+  glGetProgramiv(program_id_, GL_INFO_LOG_LENGTH, &info_log_length);
+  if (info_log_length > 0) {
+    std::vector<char> error_message(info_log_length + 1);
+    glGetProgramInfoLog(program_id_, info_log_length, NULL, &error_message[0]);
+    throw std::runtime_error(&error_message[0]);
+  }
+}
+
+namespace {
+std::string LoadFile(const std::string& filename) {
+  std::ifstream file(filename.c_str(), std::ios::in);
+  if (!file.is_open())
+    throw std::runtime_error("Error opening shader file: " + filename);
+  std::stringstream content;
+  content << file.rdbuf();
+  file.close();
+  return content.str();
+}
+}  // namespace
+
+void ShaderProgram::LoadFromFiles(const std::string& vertex_shader_file,
+                                  const std::string& fragment_shader_file) {
+  LoadFromSources(LoadFile(vertex_shader_file), LoadFile(fragment_shader_file));
+}
+
+GLint ShaderProgram::GetUniformLocation(const std::string& uniform_name) const {
+  GLint id = glGetUniformLocation(program_id_, uniform_name.c_str());
+  if (id < 0)
+    throw std::runtime_error("Cannot get shader uniform " + uniform_name);
+  return id;
+}
+
+void ShaderProgram::SetUniformValue1f(const std::string& uniform_name,
+                                      float value) const {
+  glUniform1f(GetUniformLocation(uniform_name), value);
+}
+
+void ShaderProgram::Use() const { glUseProgram(program_id_); }
+
+void ShaderProgram::Unuse() const { glUseProgram(0); }
+
+ShaderProgram::~ShaderProgram() {
+  glUseProgram(0);
+  glDeleteProgram(program_id_);
+}
+
+}  // namespace gl
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/gl_renderer/shader_program.h
+++ b/geometry/render/gl_renderer/shader_program.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <string>
+
+#include "drake/common/drake_copyable.h"
+#include "drake/geometry/render/gl_renderer/opengl_includes.h"
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace gl {
+
+/** Definition of a GLSL shader program including a vertex and fragment shader.
+ All operations on this shader program require an active OpenGL context. In
+ fact, they require the same context which was active when the program was
+ "loaded".  */
+class ShaderProgram {
+ public:
+  DRAKE_DEFAULT_COPY_AND_MOVE_AND_ASSIGN(ShaderProgram)
+
+  ShaderProgram() = default;
+
+  ~ShaderProgram();
+
+  /** Loads a %ShaderProgram from GLSL code contained in the provided strings.
+   */
+  void LoadFromSources(const std::string& vertex_shader_source,
+                       const std::string& fragment_shader_source);
+
+  /** Loads a %ShaderProgram from GLSL code contained in the named files.  */
+  void LoadFromFiles(const std::string& vertex_shader_file,
+                     const std::string& fragment_shader_file);
+
+  /** Provides the location of the named shader uniform parameter.  */
+  GLint GetUniformLocation(const std::string& uniform_name) const;
+
+  /** Sets the scalar uniform value to the given value.  */
+  void SetUniformValue1f(const std::string& uniform_name, float value) const;
+
+  /** Binds the program for usage.  */
+  void Use() const;
+
+  /** Unbinds the program.  */
+  void Unuse() const;
+
+ private:
+  GLuint program_id_{0};
+};
+
+}  // namespace gl
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/gl_renderer/test/opengl_context_test.cc
+++ b/geometry/render/gl_renderer/test/opengl_context_test.cc
@@ -1,0 +1,27 @@
+#include "drake/geometry/render/gl_renderer/opengl_context.h"
+
+#include <gtest/gtest.h>
+
+namespace drake {
+namespace geometry {
+namespace render {
+namespace gl {
+namespace {
+
+// Tests that an OpenGL context can be obtained.
+GTEST_TEST(OpenGlContext, GetContext) {
+  std::shared_ptr<OpenGlContext> opengl_context(
+      std::make_shared<OpenGlContext>());
+  EXPECT_TRUE(opengl_context->is_initialized());
+  opengl_context->make_current();
+
+  // Tests that a second context doesn't reinitialize GLUT.
+  std::shared_ptr<OpenGlContext> multiple_context(
+      std::make_shared<OpenGlContext>());
+}
+
+}  // namespace
+}  // namespace gl
+}  // namespace render
+}  // namespace geometry
+}  // namespace drake

--- a/geometry/render/gl_renderer/test/render_engine_gl_test.cc
+++ b/geometry/render/gl_renderer/test/render_engine_gl_test.cc
@@ -1,18 +1,579 @@
+#include "drake/geometry/render/gl_renderer/render_engine_gl.h"
+
+#include <array>
+#include <unordered_map>
+
 #include <gtest/gtest.h>
 
+#include "drake/common/find_resource.h"
+#include "drake/geometry/geometry_ids.h"
+#include "drake/geometry/geometry_roles.h"
 #include "drake/geometry/render/gl_renderer/render_engine_gl_factory.h"
+#include "drake/geometry/render/render_label.h"
+#include "drake/systems/sensors/color_palette.h"
+#include "drake/systems/sensors/image.h"
 
 namespace drake {
 namespace geometry {
 namespace render {
+namespace gl {
 namespace {
 
-// Tests the temporary dummy implementation of RenderEngineGl doesn't crash.
-GTEST_TEST(RenderEngineGl, DummyRenderDepthImage) {
-  std::unique_ptr<RenderEngine> engine = MakeRenderEngineGl();
+using Eigen::Translation3d;
+using Eigen::Vector3d;
+using Eigen::Vector4d;
+using math::RigidTransformd;
+using std::make_unique;
+using std::unique_ptr;
+using std::unordered_map;
+using systems::sensors::ColorI;
+using systems::sensors::ImageDepth32F;
+using systems::sensors::InvalidDepth;
+
+// Default camera properties.
+const int kWidth = 640;
+const int kHeight = 480;
+const double kZNear = 0.5;
+const double kZFar = 5.;
+const double kFovY = M_PI_4;
+
+// NOTE: The depth tolerance is this large mostly due to the combination of
+// several factors:
+//   - the sphere test (sphere against terrain)
+//   - The even-valued window dimensions
+//   - the tests against various camera properties
+// The explanation is as follows. The distance to the sphere is only exactly
+// 2 at the point of the sphere directly underneath the camera (the sphere's
+// "peak"). However, with an even-valued window dimension, we never really
+// sample that point. We sample the center of pixels all evenly arrayed around
+// that point. So, that introduces some error. As the image gets *smaller* the
+// pixels get bigger and so the distance away from the peak center increases,
+// which, in turn, increase the measured distance for the fragment. This
+// tolerance accounts for the test case where one image has pixels that are *4X*
+// larger (in area) than the default image size.
+const double kDepthTolerance = 2.5e-4;  // meters.
+
+// Holds `(x, y)` indices of the screen coordinate system where the ranges of
+// `x` and `y` are [0, image_width) and [0, image_height) respectively.
+struct ScreenCoord {
+  ScreenCoord(int x_in, int y_in) : x(x_in), y(y_in) {}
+  int x{};
+  int y{};
+};
+
+std::ostream& operator<<(std::ostream& out, const ScreenCoord& c) {
+  out << "(" << c.x << ", " << c.y << ")";
+  return out;
+}
+
+class RenderEngineGlTest : public ::testing::Test {
+ public:
+  RenderEngineGlTest()
+      : depth_(kWidth, kHeight),
+        // Looking straight down from 3m above the ground.
+        X_WR_(Translation3d(0, 0, kDefaultDistance) *
+              Eigen::AngleAxisd(M_PI, Vector3d::UnitY()) *
+              Eigen::AngleAxisd(-M_PI_2, Vector3d::UnitZ())),
+        geometry_id_(GeometryId::get_new_id()) {}
+
+ protected:
+  // Method to allow the normal case (render with the built-in renderer against
+  // the default camera) to the member images with default window visibility.
+  // This interface allows that to be completely reconfigured by the calling
+  // test.
+  void Render(RenderEngineGl* renderer = nullptr,
+              const DepthCameraProperties* camera_in = nullptr,
+              ImageDepth32F* depth_in = nullptr) {
+    if (!renderer) renderer = renderer_.get();
+    const DepthCameraProperties& camera = camera_in ? *camera_in : camera_;
+    ImageDepth32F* depth = depth_in ? depth_in : &depth_;
+    EXPECT_NO_THROW(renderer->RenderDepthImage(camera, depth));
+  }
+
+  // Confirms that all pixels in the member depth image have the same value.
+  void VerifyUniformDepth(float depth) {
+    if (depth == std::numeric_limits<float>::infinity()) {
+      for (int y = 0; y < kHeight; ++y) {
+        for (int x = 0; x < kWidth; ++x) {
+          ASSERT_EQ(depth_.at(x, y)[0], depth);
+        }
+      }
+    } else {
+      for (int y = 0; y < kHeight; ++y) {
+        for (int x = 0; x < kWidth; ++x) {
+          ASSERT_NEAR(depth_.at(x, y)[0], depth, kDepthTolerance);
+        }
+      }
+    }
+  }
+
+  // Report the coordinates of the set of "outlier" pixels for a given set of
+  // camera properties. These are the pixels that are drawn on by the
+  // background (possibly flat plane, possibly sky) and not the primary
+  // geometry.
+  static std::vector<ScreenCoord> GetOutliers(const CameraProperties& camera) {
+    return std::vector<ScreenCoord>{
+        {kInset, kInset},
+        {kInset, camera.height - kInset - 1},
+        {camera.width - kInset - 1, camera.height - kInset - 1},
+        {camera.width - kInset - 1, kInset}};
+  }
+
+  // Compute the coordinate of the pixel that is drawn on by the primary
+  // geometry given a set of camera properties.
+  static ScreenCoord GetInlier(const CameraProperties& camera) {
+    return ScreenCoord(camera.width / 2, camera.height / 2);
+  }
+
+  // Tests that the depth value in the given `image` at the given `coord` is
+  // the expected depth to within a tolerance. Handles the special case where
+  // the expected distance is infinity.
+  static ::testing::AssertionResult IsExpectedDepth(const ImageDepth32F& image,
+                                                    const ScreenCoord& coord,
+                                                    float expected_depth,
+                                                    float tolerance) {
+    const float actual_depth = image.at(coord.x, coord.y)[0];
+    if (expected_depth == std::numeric_limits<float>::infinity()) {
+      if (actual_depth == expected_depth) {
+        return ::testing::AssertionSuccess();
+      } else {
+        return ::testing::AssertionFailure()
+               << "Expected depth at " << coord << " to be "
+               << "infinity. Found: " << actual_depth;
+      }
+    } else {
+      float delta = std::abs(expected_depth - actual_depth);
+      if (delta <= tolerance) {
+        return ::testing::AssertionSuccess();
+      } else {
+        return ::testing::AssertionFailure()
+               << "Expected depth at " << coord << " to be " << expected_depth
+               << ". Found " << actual_depth << ". Difference " << delta
+               << "is greater than tolerance " << tolerance;
+      }
+    }
+  }
+
+  // Verifies the "outlier" pixels for the given camera belong to the terrain.
+  // If images are provided, the given images will be tested, otherwise the
+  // member images will be tested.
+  void VerifyOutliers(const RenderEngineGl& renderer,
+                      const DepthCameraProperties& camera, const char* name,
+                      ImageDepth32F* depth_in = nullptr) {
+    ImageDepth32F& depth = depth_in ? *depth_in : depth_;
+
+    for (const auto& screen_coord : GetOutliers(camera)) {
+      // Depth
+      EXPECT_TRUE(IsExpectedDepth(depth, screen_coord, expected_outlier_depth_,
+                                  kDepthTolerance))
+          << name;
+    }
+  }
+
+  void SetUp() override {}
+
+  // All tests on this class must invoke this first.
+  void SetUp(const RigidTransformd& X_WR, bool add_terrain = false) {
+    renderer_ = make_unique<RenderEngineGl>();
+    renderer_->UpdateViewpoint(X_WR);
+
+    if (add_terrain) {
+      const GeometryId ground_id = GeometryId::get_new_id();
+      renderer_->RegisterVisual(ground_id, HalfSpace(), PerceptionProperties(),
+                                RigidTransformd::Identity(),
+                                false /** needs update */);
+    }
+  }
+
+  // Creates a simple perception properties set for fixed, known results.
+  PerceptionProperties simple_material() const {
+    PerceptionProperties material;
+    Vector4d color(kDefaultVisualColor.r / 255., kDefaultVisualColor.g / 255.,
+                   kDefaultVisualColor.b / 255., 1.);
+    material.AddProperty("phong", "diffuse", color);
+    // NOTE: Any render label is sufficient; we aren't  testing them for this
+    // depth-only renderer.
+    material.AddProperty("label", "id", RenderLabel::kEmpty);
+    return material;
+  }
+
+  // Populates the given renderer with the sphere required for
+  // PerformCenterShapeTest().
+  void PopulateSphereTest(RenderEngineGl* renderer) {
+    Sphere sphere{0.5};
+    renderer->RegisterVisual(geometry_id_, sphere, PerceptionProperties(),
+                             RigidTransformd::Identity(),
+                             true /* needs update */);
+    RigidTransformd X_WV{Vector3d{0, 0, 0.5}};
+    X_WV_.clear();
+    X_WV_.insert({geometry_id_, X_WV});
+    renderer->UpdatePoses(X_WV_);
+  }
+
+  // Performs the work to test the rendering with a sphere centered in the
+  // image. To pass, the renderer will have to have been populated with a
+  // compliant sphere and camera configuration (e.g., PopulateSphereTest()).
+  // If force_hidden is true, then the render windows will be suppressed
+  // regardless of any other settings.
+  void PerformCenterShapeTest(RenderEngineGl* renderer, const char* name,
+                              const DepthCameraProperties* camera = nullptr) {
+    const DepthCameraProperties& cam = camera ? *camera : camera_;
+    // Can't use the member images in case the camera has been configured to a
+    // different size than the default camera_ configuration.
+    ImageDepth32F depth(cam.width, cam.height);
+    Render(renderer, &cam, &depth);
+
+    VerifyOutliers(*renderer, cam, name, &depth);
+
+    // Verifies inside the sphere.
+    const ScreenCoord inlier = GetInlier(cam);
+    EXPECT_TRUE(
+        IsExpectedDepth(depth, inlier, expected_object_depth_, kDepthTolerance))
+        << name;
+  }
+
+  // Provide a default visual color for this tests -- it is intended to be
+  // different from the default color of the VTK render engine.
+  const ColorI kDefaultVisualColor = {229u, 229u, 229u};
+  const float kDefaultDistance{3.f};
+
+  // Values to be used with the "centered shape" tests.
+  // The amount inset from the edge of the images to *still* expect terrain
+  // values.
+  static constexpr int kInset{10};
+  float expected_outlier_depth_{3.f};
+  float expected_object_depth_{2.f};
+
+  const DepthCameraProperties camera_ = {kWidth, kHeight, kFovY,
+                                         "n/a",  kZNear,  kZFar};
+  ImageDepth32F depth_;
+  RigidTransformd X_WR_;
+  GeometryId geometry_id_;
+
+  // The pose of the sphere created in PopulateSphereTest().
+  unordered_map<GeometryId, RigidTransformd> X_WV_;
+
+  unique_ptr<RenderEngineGl> renderer_;
+};
+
+// Tests an empty image -- confirms that it clears to the "empty" color -- no
+// use of "inlier" or "outlier" pixel locations.
+TEST_F(RenderEngineGlTest, NoBodyTest) {
+  SetUp(RigidTransformd::Identity());
+  Render();
+
+  VerifyUniformDepth(std::numeric_limits<float>::infinity());
+}
+
+// Tests an image with *only* terrain (perpendicular to the camera's forward
+// direction) -- no use of "inlier" or "outlier" pixel locations.
+TEST_F(RenderEngineGlTest, TerrainTest) {
+  SetUp(X_WR_, true);
+
+  // At two different distances.
+  Vector3d p_WR = X_WR_.translation();
+  for (auto depth : std::array<float, 2>({{2.f, 4.9999f}})) {
+    p_WR.z() = depth;
+    X_WR_.set_translation(p_WR);
+    renderer_->UpdateViewpoint(X_WR_);
+    Render();
+    VerifyUniformDepth(depth);
+  }
+
+  // Closer than kZNear.
+  p_WR.z() = kZNear - 1e-5;
+  X_WR_.set_translation(p_WR);
+  renderer_->UpdateViewpoint(X_WR_);
+  Render();
+  VerifyUniformDepth(InvalidDepth::kTooClose);
+
+  // Farther than kZFar.
+  p_WR.z() = kZFar + 1e-3;
+  X_WR_.set_translation(p_WR);
+  renderer_->UpdateViewpoint(X_WR_);
+  Render();
+  // Verifies depth.
+  for (int y = 0; y < kHeight; ++y) {
+    for (int x = 0; x < kWidth; ++x) {
+      ASSERT_EQ(InvalidDepth::kTooFar, depth_.at(x, y)[0]);
+    }
+  }
+}
+
+// Performs the shape centered in the image with a sphere.
+TEST_F(RenderEngineGlTest, SphereTest) {
+  SetUp(X_WR_, true);
+
+  PopulateSphereTest(renderer_.get());
+
+  PerformCenterShapeTest(renderer_.get(), "Sphere test");
+}
+
+// This confirms that geometries are correctly removed from the render engine.
+// We add two new geometries (testing the rendering after each addition).
+// By removing the first of the added geometries, we can confirm that the
+// remaining geometries are re-ordered appropriately. Then by removing the,
+// second we should restore the original default image.
+//
+// The default image is based on a sphere sitting on a plane at z = 0 with the
+// camera located above the sphere's center and aimed at that center.
+// THe default sphere is drawn with `●`, the first added sphere with `x`, and
+// the second with `o`. The height of the top of each sphere and its depth in
+// the camera's depth sensors are indicated as zᵢ and dᵢ, i ∈ {0, 1, 2},
+// respectively.
+//
+//             /|\       <---- camera_z = 3
+//              v
+//
+//
+//
+//
+//            ooooo       <---- z₂ = 4r = 2, d₂ = 1
+//          oo     oo
+//         o         o
+//        o           o
+//        o           o
+//        o   xxxxx   o   <---- z₁ = 3r = 1.5, d₁ = 1.5
+//         oxx     xxo
+//         xoo     oox
+//        x   ooooo   x
+//        x   ●●●●●   x   <---- z₀ = 2r = 1, d₀ = 2
+//        x ●●     ●● x
+//         ●         ●
+//        ● xx     xx ●
+// z      ●   xxxxx   ●
+// ^      ●           ●
+// |       ●         ●
+// |        ●●     ●●
+// |__________●●●●●____________
+//
+TEST_F(RenderEngineGlTest, RemoveVisual) {
+  SetUp(X_WR_, true);
+  const float default_depth = expected_object_depth_;
+
+  // Positions a sphere centered at <0, 0, z> with the given color.
+  auto add_sphere = [this](double z, GeometryId geometry_id) {
+    const double kRadius = 0.5;
+    Sphere sphere{kRadius};
+    const float depth = kDefaultDistance - kRadius - z;
+    PerceptionProperties material;
+    renderer_->RegisterVisual(geometry_id, sphere, material,
+                              RigidTransformd::Identity(), true);
+    RigidTransformd X_WV{Translation3d(0, 0, z)};
+    X_WV_.insert({geometry_id, X_WV});
+    renderer_->UpdatePoses(X_WV_);
+    return depth;
+  };
+
+  // Sets the expected values prior to calling PerformCenterShapeTest().
+  auto set_expectations = [this](float depth) {
+    expected_object_depth_ = depth;
+  };
+
+  const GeometryId id0 = GeometryId::get_new_id();
+  const float depth0 = add_sphere(0.5, id0);
+  set_expectations(depth0);
+  PerformCenterShapeTest(renderer_.get(), "First sphere test");
+
+  // Add another sphere of a different color in front of the default sphere
+  const GeometryId id1 = GeometryId::get_new_id();
+  const float depth1 = add_sphere(0.75, id1);
+  set_expectations(depth1);
+  PerformCenterShapeTest(renderer_.get(), "Second sphere added in remove test");
+
+  // Add a _third_ sphere in front of the second.
+  const GeometryId id2 = GeometryId::get_new_id();
+  float depth2 = add_sphere(1.0, id2);
+  set_expectations(depth2);
+  PerformCenterShapeTest(renderer_.get(), "Third sphere added in remove test");
+
+  // Remove the first sphere added; should report "true" and the render test
+  // should pass without changing expectations.
+  bool removed = renderer_->RemoveGeometry(id1);
+  EXPECT_TRUE(removed);
+  PerformCenterShapeTest(renderer_.get(), "First added sphere removed");
+
+  // Remove the second added sphere; should report true and rendering should
+  // return to its default configuration.
+  removed = renderer_->RemoveGeometry(id2);
+  EXPECT_TRUE(removed);
+  set_expectations(default_depth);
+  PerformCenterShapeTest(renderer_.get(),
+                         "Default image restored by removing extra geometries");
+}
+
+// All of the clone tests use the PerformCenterShapeTest() with the sphere setup
+// to confirm that the clone is behaving as anticipated.
+
+// Tests that the cloned renderer produces the same images (i.e., passes the
+// same test).
+TEST_F(RenderEngineGlTest, SimpleClone) {
+  SetUp(X_WR_, true);
+  PopulateSphereTest(renderer_.get());
+
+  unique_ptr<RenderEngine> clone = renderer_->Clone();
+  EXPECT_NE(dynamic_cast<RenderEngineGl*>(clone.get()), nullptr);
+  PerformCenterShapeTest(dynamic_cast<RenderEngineGl*>(clone.get()),
+                         "Simple clone");
+}
+
+// Tests that the cloned renderer still works, even when the original is
+// deleted.
+TEST_F(RenderEngineGlTest, ClonePersistence) {
+  SetUp(X_WR_, true);
+  PopulateSphereTest(renderer_.get());
+
+  unique_ptr<RenderEngine> clone = renderer_->Clone();
+  // This causes the original renderer copied from to be destroyed.
+  renderer_.reset();
+  ASSERT_EQ(nullptr, renderer_);
+  PerformCenterShapeTest(static_cast<RenderEngineGl*>(clone.get()),
+                         "Clone persistence");
+}
+
+// Tests that the cloned renderer still works, even when the original has values
+// RenderEngineGlTest
+TEST_F(RenderEngineGlTest, CloneIndependence) {
+  SetUp(X_WR_, true);
+  PopulateSphereTest(renderer_.get());
+
+  unique_ptr<RenderEngine> clone = renderer_->Clone();
+  // Move the terrain *up* 10 units in the z.
+  RigidTransformd X_WT_new{Translation3d{0, 0, 10}};
+  // This assumes that the terrain is zero-indexed.
+  renderer_->UpdatePoses(
+      unordered_map<GeometryId, RigidTransformd>{{geometry_id_, X_WT_new}});
+  PerformCenterShapeTest(dynamic_cast<RenderEngineGl*>(clone.get()),
+                         "Clone independence");
+}
+
+// Confirm that the renderer can be used for cameras with different properties.
+// I.e., the camera intrinsics are defined *outside* the renderer.
+TEST_F(RenderEngineGlTest, DifferentCameras) {
+  SetUp(X_WR_, true);
+  PopulateSphereTest(renderer_.get());
+
+  // Baseline -- confirm that all of the defaults in this test still produce
+  // the expected outcome.
+  PerformCenterShapeTest(renderer_.get(), "Camera change - baseline", &camera_);
+
+  // Test changes in sensor sizes.
+  {
+    // Now run it again with a camera with a smaller sensor (quarter area).
+    DepthCameraProperties small_camera{camera_};
+    small_camera.width /= 2;
+    small_camera.height /= 2;
+    PerformCenterShapeTest(renderer_.get(), "Camera change - small camera",
+                           &small_camera);
+
+    // Now run it again with a camera with a bigger sensor (4X area).
+    DepthCameraProperties big_camera{camera_};
+    big_camera.width *= 2;
+    big_camera.height *= 2;
+    PerformCenterShapeTest(renderer_.get(), "Camera change - big camera",
+                           &big_camera);
+  }
+
+  // Test changes in fov (larger and smaller).
+  {
+    DepthCameraProperties narrow_fov(camera_);
+    narrow_fov.fov_y /= 2;
+    PerformCenterShapeTest(renderer_.get(), "Camera change - narrow fov",
+                           &narrow_fov);
+
+    DepthCameraProperties wide_fov(camera_);
+    wide_fov.fov_y *= 2;
+    PerformCenterShapeTest(renderer_.get(), "Camera change - wide fov",
+                           &wide_fov);
+  }
+
+  // Test changes to depth range.
+  {
+    DepthCameraProperties clipping_far_plane(camera_);
+    clipping_far_plane.z_far = expected_outlier_depth_ - 0.1;
+    const float old_outlier_depth = expected_outlier_depth_;
+    expected_outlier_depth_ = std::numeric_limits<float>::infinity();
+    PerformCenterShapeTest(renderer_.get(),
+                           "Camera change - z far clips terrain",
+                           &clipping_far_plane);
+    // NOTE: Need to restored expected outlier depth for next test.
+    expected_outlier_depth_ = old_outlier_depth;
+
+    DepthCameraProperties clipping_near_plane(camera_);
+    clipping_near_plane.z_near = expected_object_depth_ + 0.1;
+    const float old_object_depth_ = expected_object_depth_;
+    expected_object_depth_ = 0;
+    PerformCenterShapeTest(renderer_.get(), "Camera change - z near clips mesh",
+                           &clipping_near_plane);
+    // NOTE: Need to restored expected object depth for next test.
+    expected_object_depth_ = old_object_depth_;
+
+    // Test rendering with a previous camera once again to make sure the
+    // existing target is reused correctly.
+    expected_outlier_depth_ = std::numeric_limits<float>::infinity();
+    PerformCenterShapeTest(renderer_.get(),
+                           "Camera change - z far clips terrain",
+                           &clipping_far_plane);
+  }
+}
+
+// Tests that registered geometry without specific values renders without error.
+// TODO(SeanCurtis-TRI): When the ability to set defaults is exposed through a
+// public API, actually test for the *default values*. Until then, error-free
+// rendering is sufficient.
+TEST_F(RenderEngineGlTest, DefaultProperties) {
+  SetUp(X_WR_, false /* no terrain */);
+
+  // Sets up a sphere.
+  Sphere sphere(1);
+  const GeometryId id = GeometryId::get_new_id();
+  renderer_->RegisterVisual(id, sphere, PerceptionProperties(),
+                            RigidTransformd::Identity(), true);
+  RigidTransformd X_WV{Translation3d(0, 0, 0.5)};
+  renderer_->UpdatePoses(
+      unordered_map<GeometryId, RigidTransformd>{{id, X_WV}});
+
+  EXPECT_NO_THROW(Render());
+}
+
+// This is a test to make sure that independent renders are truly independent.
+// So, we're going to do a bunch of interleaved operations on the two renderers
+// to make sure that each is still correct.
+TEST_F(RenderEngineGlTest, MultipleRenderers) {
+  RenderEngineGl engine1;
+  RenderEngineGl engine2;
+  const GeometryId ground = GeometryId::get_new_id();
+
+  auto add_terrain = [ground](auto* renderer) {
+    renderer->RegisterVisual(ground, HalfSpace(), PerceptionProperties(),
+                             RigidTransformd::Identity(),
+                             false /** needs update */);
+  };
+
+  engine1.UpdateViewpoint(X_WR_);
+  add_terrain(&engine1);
+  PopulateSphereTest(&engine1);
+  PerformCenterShapeTest(&engine1, "engine1 - initial render");
+
+  Render(&engine2);
+  VerifyUniformDepth(std::numeric_limits<float>::infinity());
+
+  engine2.UpdateViewpoint(X_WR_);
+  add_terrain(&engine2);
+  Sphere sphere(0.576);
+  const GeometryId sphere_id = GeometryId::get_new_id();
+  engine2.RegisterVisual(sphere_id, sphere, simple_material(),
+                         RigidTransformd::Identity(), true);
+  RigidTransformd X_WV{Translation3d(0.2, 0.2, 0.5)};
+  engine2.UpdatePoses(
+      unordered_map<GeometryId, RigidTransformd>{{sphere_id, X_WV}});
+  PerformCenterShapeTest(&engine2, "engine2 - offset sphere test");
+
+  PerformCenterShapeTest(&engine1, "engine1 - second render");
 }
 
 }  // namespace
+}  // namespace gl
 }  // namespace render
 }  // namespace geometry
 }  // namespace drake

--- a/setup/ubuntu/binary_distribution/packages-bionic.txt
+++ b/setup/ubuntu/binary_distribution/packages-bionic.txt
@@ -2,6 +2,7 @@ coinor-libclp1
 coinor-libcoinutils3v5
 coinor-libipopt1v5
 default-jre
+freeglut3
 graphviz
 jupyter-notebook
 libamd2
@@ -12,6 +13,7 @@ libexpat1
 libgflags2.2
 libgfortran4
 libgl1-mesa-glx
+libglew2.0
 libglib2.0-0
 libhdf5-100
 libjpeg8

--- a/setup/ubuntu/source_distribution/packages-bionic.txt
+++ b/setup/ubuntu/source_distribution/packages-bionic.txt
@@ -9,6 +9,7 @@ doxygen
 file
 fonts-dejavu-core
 fonts-dejavu-extra
+freeglut3-dev
 gdb
 gfortran
 git
@@ -20,6 +21,7 @@ libclang-6.0-dev
 libexpat1-dev
 libfreetype6-dev
 libgflags-dev
+libglew-dev
 libglib2.0-dev
 libglu1-mesa-dev
 libhdf5-dev

--- a/tools/install/libdrake/BUILD.bazel
+++ b/tools/install/libdrake/BUILD.bazel
@@ -162,6 +162,17 @@ cc_library(
     }),
 )
 
+# Depend on glut iff on Ubuntu and not MacOS.
+cc_library(
+    name = "glut_deps",
+    deps = select({
+        "//conditions:default": [
+            "@glut",
+        ],
+        "//tools/cc_toolchain:apple": [],
+    }),
+)
+
 # Depend on Gurobi's shared library iff Gurobi is enabled.
 cc_library(
     name = "gurobi_deps",
@@ -241,6 +252,7 @@ cc_library(
     name = "libdrake_runtime_so_deps",
     deps = [
         ":dreal_deps",
+        ":glut_deps",
         ":gurobi_deps",
         ":ipopt_deps",
         ":mosek_deps",

--- a/tools/workspace/default.bzl
+++ b/tools/workspace/default.bzl
@@ -28,6 +28,7 @@ load("@drake//tools/workspace/ghc_filesystem:repository.bzl", "ghc_filesystem_re
 load("@drake//tools/workspace/github3_py:repository.bzl", "github3_py_repository")  # noqa
 load("@drake//tools/workspace/glew:repository.bzl", "glew_repository")
 load("@drake//tools/workspace/glib:repository.bzl", "glib_repository")
+load("@drake//tools/workspace/glut:repository.bzl", "glut_repository")
 load("@drake//tools/workspace/googlebenchmark:repository.bzl", "googlebenchmark_repository")  # noqa
 load("@drake//tools/workspace/gtest:repository.bzl", "gtest_repository")
 load("@drake//tools/workspace/gurobi:repository.bzl", "gurobi_repository")
@@ -149,6 +150,8 @@ def add_default_repositories(excludes = [], mirrors = DEFAULT_MIRRORS):
         glew_repository(name = "glew")
     if "glib" not in excludes:
         glib_repository(name = "glib")
+    if "glut" not in excludes:
+        glut_repository(name = "glut")
     if "googlebenchmark" not in excludes:
         googlebenchmark_repository(name = "googlebenchmark", mirrors = mirrors)
     if "gtest" not in excludes:

--- a/tools/workspace/glut/BUILD.bazel
+++ b/tools/workspace/glut/BUILD.bazel
@@ -1,0 +1,8 @@
+# -*- python -*-
+
+# This file exists to make our directory into a Bazel package, so that our
+# neighboring *.bzl file can be loaded elsewhere.
+
+load("//tools/lint:lint.bzl", "add_lint_tests")
+
+add_lint_tests()

--- a/tools/workspace/glut/package-macos.BUILD.bazel
+++ b/tools/workspace/glut/package-macos.BUILD.bazel
@@ -1,0 +1,9 @@
+# -*- python -*-
+
+package(default_visibility = ["//visibility:public"])
+
+# On macOS, no targets should depend on @glut.
+cc_library(
+    name = "glut",
+    srcs = ["missing-macos.cc"],
+)

--- a/tools/workspace/glut/package.BUILD.bazel
+++ b/tools/workspace/glut/package.BUILD.bazel
@@ -1,0 +1,23 @@
+# -*- python -*-
+
+load(":vars.bzl", "LIBDIR")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "glut",
+    hdrs = [
+        "include/freeglut.h",
+        "include/freeglut_ext.h",
+        "include/freeglut_std.h",
+        "include/glut.h",
+    ],
+    includes = [
+        "include",
+    ],
+    linkopts = [
+        "-L" + LIBDIR,
+        "-lglut",
+    ],
+    licenses = ["notice"],  # X-Consortium.
+)

--- a/tools/workspace/glut/repository.bzl
+++ b/tools/workspace/glut/repository.bzl
@@ -1,0 +1,53 @@
+# -*- mode: python -*-
+
+load(
+    "@drake//tools/workspace:os.bzl",
+    "determine_os",
+)
+load(
+    "@drake//tools/workspace:pkg_config.bzl",
+    "setup_pkg_config_repository",
+)
+
+def _impl(repo_ctx):
+    # Only available on Ubuntu. On macOS, no targets should depend on @opengl.
+    os_result = determine_os(repo_ctx)
+    if os_result.error != None:
+        fail(os_result.error)
+    if os_result.is_ubuntu:
+        include = "/usr/include/GL"
+        lib = "/usr/lib"
+
+        # Grab the relevant headers.
+        hdrs = [
+            "freeglut.h",
+            "freeglut_ext.h",
+            "freeglut_std.h",
+            "glut.h",
+        ]
+        for hdr in hdrs:
+            repo_ctx.symlink(include + "/" + hdr, "include/" + hdr)
+
+        # Declare the libdir.
+        repo_ctx.file(
+            "vars.bzl",
+            content = "LIBDIR = \"{}\"\n".format(lib),
+            executable = False,
+        )
+
+        # Add the BUILD file.
+        repo_ctx.symlink(
+            Label("@drake//tools/workspace/glut:package.BUILD.bazel"),
+            "BUILD.bazel",
+        )
+
+    else:
+        repo_ctx.symlink(
+            Label("@drake//tools/workspace/glut:package-macos.BUILD.bazel"),
+            "BUILD.bazel",
+        )
+
+glut_repository = repository_rule(
+    local = True,
+    implementation = _impl,
+)


### PR DESCRIPTION
This has been split up from render-gl-port to keep PR size down.
Sphere and Halfspace are required for the basic depth tests,
the rest of the geometry implementation is in a follow-up PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tehbelinda/drake/5)
<!-- Reviewable:end -->
